### PR TITLE
Fixing a compile error around sending data using logWithLevel

### DIFF
--- a/ios/RollbarReactNative.m
+++ b/ios/RollbarReactNative.m
@@ -17,7 +17,7 @@
 }
 
 + (void)logWithLevel:(NSString*)level message:(NSString*)message data:(NSDictionary*)data {
-  [Rollbar logWithLevel:level message:message message:data];
+  [Rollbar logWithLevel:level message:message data:data];
 }
 
 + (void)logWithLevel:(NSString*)level data:(NSDictionary*)data {


### PR DESCRIPTION
When I tried to build master locally there appeared to be a small issue around the logWithLevel. 

Thank you for the fantastic product and bringing support to react native.

My Testing:

* Building within a react native app and performing basic logging