### PR TITLE
Be able to change compileSdkVersion and buildToolsVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion project.hasProperty('compileSdkVersion') ? project.compileSdkVersion : 23
+    buildToolsVersion project.hasProperty('buildToolsVersion') ? project.buildToolsVersion : "23.0.1"
 
     defaultConfig {
         minSdkVersion 19


### PR DESCRIPTION
With version `compileSdkVersion 23`, I'm having this error https://stackoverflow.com/questions/49331411/errorresource-androidstyle-textappearance-material-widget-button-borderless-co?rq=1 

The solution for me was to update `compileSdkVersion` to 26