### PR TITLE
Update Gradle Build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 node_modules/
 npm-debug.log
 yarn-error.log
-  
+
 
 # Xcode
 #
@@ -29,7 +29,7 @@ DerivedData
 *.ipa
 *.xcuserstate
 project.xcworkspace
-      
+
 
 # Android/IntelliJ
 #
@@ -43,4 +43,3 @@ local.properties
 buck-out/
 \.buckd/
 *.keystore
-      

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,8 +13,8 @@ android {
 }
 
 dependencies {
-    compile 'com.rollbar:rollbar-api:1.2.0'
-    compile 'com.rollbar:rollbar-java:1.2.0'
-    compile 'com.rollbar:rollbar-android:1.2.0@aar'
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.rollbar:rollbar-api:1.2.0'
+    implementation 'com.rollbar:rollbar-java:1.2.0'
+    implementation 'com.rollbar:rollbar-android:1.2.0@aar'
+    implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
* To be compatible with Gradle version 4.6 and the Android Gradle
  plugin version 3.2.1, the build.gradle file must be updated.
* Fix a deprecation warning by renaming `compile` => `implementation`.

Resolves: https://github.com/rollbar/rollbar-react-native/issues/59