### PR TITLE
Compatibility fixes

### DIFF
--- a/ios/RollbarReactNative.m
+++ b/ios/RollbarReactNative.m
@@ -202,7 +202,7 @@ NSString* updateConfiguration(RollbarConfiguration *config, NSDictionary *option
     config.endpoint = [RCTConvert NSString:options[@"endpoint"]];
   }
   if (options[@"logLevel"]) {
-    config.crashLevel = [RCTConvert NSString:options[@"endpoint"]];
+    config.crashLevel = [RCTConvert NSString:options[@"logLevel"]];
   }
   if (options[@"notifier"]) {
     NSDictionary *notifierConfig = [RCTConvert NSDictionary:options[@"notifier"]];

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "react-native": ">=0.50"
   },
   "dependencies": {
-    "buffer": "^5.0.7",
+    "buffer": "^4.9.1 || ^5.0.7",
     "promise": "^8.0.1",
     "rollbar": "^2.13.0",
     "url": "^0.11.0"

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  dependency: {
+    platforms: {
+      android: {
+        "packageInstance": "RollbarReactNative.getPackage()",
+        "packageImportPath": "import com.rollbar.RollbarReactNative;"
+      },
+    }
+  }
+}


### PR DESCRIPTION
Several unrelated compatibility fixes:

Fixes: 
* https://github.com/rollbar/rollbar-react-native/issues/78
* https://github.com/rollbar/rollbar-react-native/issues/80
* https://github.com/rollbar/rollbar-react-native/issues/81

Note:
rnpm cofig is left in place to ensure compatibility with older react-native CLI. It wasn't clear to me  when react-native.config.js was fully supported, as there was a large refactor Apr 1, 2019. (https://github.com/react-native-community/cli/pull/254) Or perhaps that was when it was first supported. When react-native.config.js is used, rnpm is ignored and there are no warnings.
