### PR TITLE
fix: build with use_framework within CocoaPods

### DIFF
--- a/ios/RollbarReactNative.h
+++ b/ios/RollbarReactNative.h
@@ -3,7 +3,11 @@
 #else
 #import "RCTBridgeModule.h"
 #endif
+#if __has_include(<Rollbar/Rollbar.h>)
+#import <Rollbar/Rollbar.h>
+#else
 #import "Rollbar.h"
+#endif
 
 @interface RollbarReactNative : NSObject <RCTBridgeModule>
 

--- a/ios/RollbarReactNative.m
+++ b/ios/RollbarReactNative.m
@@ -1,5 +1,9 @@
 #import "RollbarReactNative.h"
+#if __has_include(<React/RCTConvert.h>)
 #import <React/RCTConvert.h>
+#else
+#import "RCTConvert.h"
+#endif
 
 @implementation RollbarReactNative
 


### PR DESCRIPTION
- use_framework! is necessary for certain swift libraries and it makes certain header incompatible
- to fix that, use the same __has_include used for RCTBridgeModule on all the other imports
- tested on a fresh project without use_framework and a more involved project containing use_framework
- related https://github.com/facebook/react-native/pull/25393/files and https://github.com/facebook/react-native/issues/25349