### PR TITLE
Send device attributes in payload client key

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,4 +17,5 @@ dependencies {
     implementation 'com.rollbar:rollbar-java:1.4.0'
     implementation 'com.rollbar:rollbar-android:1.4.0@aar'
     implementation 'com.facebook.react:react-native:+'
+    implementation 'com.google.code.gson:gson:+'
 }

--- a/android/src/main/java/com/rollbar/RollbarReactNative.java
+++ b/android/src/main/java/com/rollbar/RollbarReactNative.java
@@ -2,6 +2,8 @@ package com.rollbar;
 
 import java.util.Map;
 
+import com.google.gson.JsonObject;
+
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -10,6 +12,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 
 import android.content.Context;
+import android.os.Build;
 
 import com.rollbar.android.Rollbar;
 import com.rollbar.android.provider.NotifierProvider;
@@ -514,5 +517,23 @@ public class RollbarReactNative extends ReactContextBaseJavaModule {
   @ReactMethod
   public void clearPerson() {
       Rollbar.instance().clearPersonData();
+  }
+
+  // Defined as synchronous because the data must be returned in the
+  // javascript configuration constructor before Rollbar.js is initialized.
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  public String deviceAttributes() {
+    JsonObject attributes = new JsonObject();
+
+    attributes.addProperty("os", "android");
+    attributes.addProperty("phone_model", android.os.Build.MODEL);
+    attributes.addProperty("android_version", android.os.Build.VERSION.RELEASE);
+    attributes.addProperty("board", android.os.Build.BOARD);
+    attributes.addProperty("brand", android.os.Build.BRAND);
+    attributes.addProperty("device", android.os.Build.DEVICE);
+    attributes.addProperty("manufacturer", android.os.Build.MANUFACTURER);
+    attributes.addProperty("product", android.os.Build.PRODUCT);
+
+    return attributes.toString();
   }
 }

--- a/src/merge.js
+++ b/src/merge.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var hasOwn = Object.prototype.hasOwnProperty;
+var toStr = Object.prototype.toString;
+
+var isPlainObject = function isPlainObject(obj) {
+  if (!obj || toStr.call(obj) !== '[object Object]') {
+    return false;
+  }
+
+  var hasOwnConstructor = hasOwn.call(obj, 'constructor');
+  var hasIsPrototypeOf = obj.constructor && obj.constructor.prototype && hasOwn.call(obj.constructor.prototype, 'isPrototypeOf');
+  // Not own constructor property must be Object
+  if (obj.constructor && !hasOwnConstructor && !hasIsPrototypeOf) {
+    return false;
+  }
+
+  // Own properties are enumerated firstly, so to speed up,
+  // if last one is own, then all properties are own.
+  var key;
+  for (key in obj) {/**/}
+
+  return typeof key === 'undefined' || hasOwn.call(obj, key);
+};
+
+export function merge() {
+  var i, src, copy, clone, name,
+      result = {},
+     current = null,
+      length = arguments.length;
+
+  for (i=0; i < length; i++) {
+    current = arguments[i];
+    if (current == null) {
+      continue;
+    }
+
+    for (name in current) {
+      src = result[name];
+      copy = current[name];
+      if (result !== copy) {
+        if (copy && isPlainObject(copy)) {
+          clone = src && isPlainObject(src) ? src : {};
+          result[name] = merge(clone, copy);
+        } else if (typeof copy !== 'undefined') {
+          result[name] = copy;
+        }
+      }
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
Partially addresses https://github.com/rollbar/rollbar-react-native/issues/79

Adds device information attributes to the payload client key for Rollbar events in the Javascript domain. This PR only addresses static information that can be fetched once at init time. (e.g. Device ID, Model, etc.) Other dynamic properties (memory, capacity, etc.) will be addressed in a later PR.