### PR TITLE
Update rollbar-android v1.7.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,9 +13,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.rollbar:rollbar-api:1.4.0'
-    implementation 'com.rollbar:rollbar-java:1.4.0'
-    implementation 'com.rollbar:rollbar-android:1.4.0@aar'
+    implementation('com.rollbar:rollbar-android:1.7.1')
     implementation 'com.facebook.react:react-native:+'
     implementation 'com.google.code.gson:gson:+'
 }


### PR DESCRIPTION
Fixes: https://github.com/rollbar/rollbar-react-native/issues/104, https://github.com/rollbar/rollbar-react-native/issues/112

Enables uncaught exception capture in the native android environment by pulling in https://github.com/rollbar/rollbar-java/pull/200.

This also pulls in all rollbar-android updates since 1.4.0: https://github.com/rollbar/rollbar-java/releases

