### PR TITLE
Update rollbar.js 2.16.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "buffer": "^4.9.1 || ^5.0.7",
-    "rollbar": "^2.14.0",
+    "rollbar": "^2.16.1",
     "url": "^0.11.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes: https://github.com/rollbar/rollbar-react-native/issues/109

Picks up https://github.com/rollbar/rollbar.js/pull/847

More generally, picks up Rollbar.js updates since 2.14.0: (https://github.com/rollbar/rollbar.js/releases)
* Allow callbacks (`onSendCallback`, `CheckIgnore`, `transform`) in react-native target
* Only build stack for http errors when the feature is enabled
* Fixes wrong byte count for truncation
* Allow rollbar errors on xhr/fetch http status (4xx/5xx/0)
* Correctly parse method names with parens in stack traces
* gracefully handle loadFull being called multiple times
* Add CodePush Rewrite Rule
* Enable new CDN