### PR TITLE
Set captureDeviceInfo false by default

### DIFF
--- a/src/Rollbar.js
+++ b/src/Rollbar.js
@@ -116,7 +116,7 @@ export class Configuration {
     this.captureUnhandledRejections = options.captureUnhandledRejections !== undefined ? options.captureUnhandledRejections : !__DEV__;
 
     // Ensure captureDeviceInfo is set before calling payloadOptions() below.
-    this.captureDeviceInfo = options.captureDeviceInfo === undefined ? true : options.captureDeviceInfo;
+    this.captureDeviceInfo = options.captureDeviceInfo === undefined ? false : options.captureDeviceInfo;
     this.payload = merge(options.payload, this.payloadOptions());
     this.enabled = options.enabled === undefined ? true : options.enabled;
     this.verbose = options.verbose || false;


### PR DESCRIPTION
Fixes: https://github.com/rollbar/rollbar-react-native/issues/101

The Android Chrome debugger throws an error when this option is enabled, because the debugger disallows synchronous native calls. Disable by default, and people who want the metadata can enable it.