### PR TITLE
Update rollbar.js 2.16.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "buffer": "^4.9.1 || ^5.0.7",
-    "rollbar": "^2.16.1",
+    "rollbar": "^2.16.2",
     "url": "^0.11.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Pulls in: https://github.com/rollbar/rollbar.js/releases/tag/v2.16.2
Restores originalArgs used by checkIgnore, https://github.com/rollbar/rollbar.js/pull/858