### PR TITLE
Allow passing registerExceptionHandler parameter

### DIFF
--- a/android/src/main/java/com/rollbar/RollbarReactNative.java
+++ b/android/src/main/java/com/rollbar/RollbarReactNative.java
@@ -45,9 +45,13 @@ public class RollbarReactNative extends ReactContextBaseJavaModule {
   }
 
   public static void init(Context context, String accessToken, String environment) {
+    init(context, accessToken, environment, true);
+  }
+
+  public static void init(Context context, String accessToken, String environment, boolean registerExceptionHandler) {
     final String codeVersion = loadCodeVersionFromManifest(context);
 
-    Rollbar.init(context, accessToken, environment, true, false, new ConfigProvider() {
+    Rollbar.init(context, accessToken, environment, registerExceptionHandler, false, new ConfigProvider() {
       @Override
       public Config provide(ConfigBuilder builder) {
         return builder


### PR DESCRIPTION
Some developers would like to handle native crash with a different handler than rollbar. This option is already present in the native sdk.