### PR TITLE
Enable js-only Expo (no native linking required)

### DIFF
--- a/src/Rollbar.js
+++ b/src/Rollbar.js
@@ -19,12 +19,11 @@ export class Client {
 
     if (NativeClient) {
       NativeClient.init(this.config.toJSON());
-      this.captureUncaughtExceptions();
-      if (this.config.captureUnhandledRejections) {
-        this.captureUnhandledRejections();
-      }
-    } else {
-      throw new Error('Rollbar: Native client not found. Did you run react-native link?');
+    }
+
+    this.captureUncaughtExceptions();
+    if (this.config.captureUnhandledRejections) {
+      this.captureUnhandledRejections();
     }
   }
 
@@ -89,12 +88,16 @@ export class Client {
 
   setPerson = (id, name, email) => {
     this.rollbar.setPerson({id, name, email});
-    NativeClient.setPerson({id, name, email});
+    if (NativeClient) {
+      NativeClient.setPerson({id, name, email});
+    }
   }
 
   clearPerson = () => {
     this.rollbar.clearPerson();
-    NativeClient.clearPerson();
+    if (NativeClient) {
+      NativeClient.clearPerson();
+    }
   }
 }
 
@@ -158,7 +161,11 @@ export class Configuration {
   }
 
   deviceAttributes = () => {
-    return JSON.parse(NativeClient.deviceAttributes());
+    if (NativeClient) {
+      return JSON.parse(NativeClient.deviceAttributes());
+    } else {
+      return {};
+    }
   }
 
   toJSON = () => {


### PR DESCRIPTION
Fixes: https://github.com/rollbar/rollbar-react-native/issues/74

This PR allows running the JS Rollbar client without the `NativeClient` native binding. For unejected Expo apps, or any other JS only React Native app, just npm/yarn install and add to your project:

```
import { Client, Configuration } from 'rollbar-react-native'
const config = new Configuration('POST_CLIENT_ITEM_ACCESS_TOKEN', {
  logLevel: 'info'
});
const rollbar = new Client(config);
```

### Notes
This no longer throws when the native binding is missing, and omits the message about `react-native link`. Since RN 0.60, `react-native link` is no longer used (native dependencies are autolinked), so this should be fine. Especially since JS-only apps are becoming more common.

I first looked at whether Expo apps could just import the react-native target of Rollbar.js (which is what rollbar-react-native wraps for javascript support.) This would introduce dependencies (buffer, promise) that are currently handled by the rollbar-react-native wrapper. By continuing to use rollbar-react-native, the config is simpler and no new dependencies are added to rollbar.js.

For React Native Web apps, or any app that isn't a native app and runs in a browser, the browser target of Rollbar.js should be used instead. Those environments will use the browser's `onerror` and won't have React Native's `ErrorUtils`.