### PR TITLE
Update rollbar.js to 2.19.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "buffer": "^4.9.1 || ^5.0.7",
-    "rollbar": "^2.16.1",
+    "rollbar": "^2.19.3",
     "url": "^0.11.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description of the change

Sets minimum version of Rollbar.js to pick up JSON polyfill fix - https://github.com/rollbar/rollbar.js/releases/tag/v2.19.3.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Fixes: ch72255

### Development

- [x] Lint rules pass locally

**N/A: rollbar-react-native doesn't have test automation. The change has been tested manually.** 
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
