### PR TITLE
Fix React depenedency to enable XCode 12 build

### DIFF
--- a/RollbarReactNative.podspec
+++ b/RollbarReactNative.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/author/RollbarReactNative.git', :tag => 'v0.8.0' }
   s.requires_arc = true
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
   s.dependency 'Rollbar', '~> 1.12.8'
 
   s.source_files  = 'ios/RollbarReactNative.{h,m}'


### PR DESCRIPTION
## Description of the change
Latest Xcode 12 fails to build if the module doesn't depend on React-Core. Please check the following link for me details: [facebook/react-native#29633](https://github.com/facebook/react-native/issues/29633#issuecomment-694187116)

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues
[facebook/react-native#29633](https://github.com/facebook/react-native/issues/29633#issuecomment-694187116)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
