### PR TITLE
Add missing `captureDeviceInfo` property to type definitions file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,6 +40,7 @@ export interface ConfigurationOptions {
   enabledReleaseStages?: string[];
   captureUncaught?: boolean;
   captureUnhandledRejections?: boolean;
+  captureDeviceInfo?: boolean;
   payload?: object;
   enabled?: boolean;
   verbose?: boolean;


### PR DESCRIPTION
## Description of the change
Add missing `captureDeviceInfo` property to type definitions file

https://github.com/rollbar/rollbar-react-native/issues/142

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 
## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
