### PR TITLE
handle NSNull in json argument

### DIFF
--- a/ios/RollbarReactNative.m
+++ b/ios/RollbarReactNative.m
@@ -245,9 +245,12 @@ RCT_EXPORT_METHOD(init:(NSDictionary *)options) {
 }
 
 RCT_EXPORT_METHOD(setPerson:(NSDictionary *)personInfo) {
-  NSString *identifier = personInfo[@"id"] ? [RCTConvert NSString:personInfo[@"id"]] : nil;
-  NSString *name = personInfo[@"name"] ? [RCTConvert NSString:personInfo[@"name"]] : nil;
-  NSString *email = personInfo[@"email"] ? [RCTConvert NSString:personInfo[@"email"]] : nil;
+  NSString *identifier = personInfo[@"id"] && ![personInfo[@"id"] isEqual:[NSNull null]]
+    ? [RCTConvert NSString:personInfo[@"id"]] : nil;
+  NSString *name = personInfo[@"name"] && ![personInfo[@"name"] isEqual:[NSNull null]]
+    ? [RCTConvert NSString:personInfo[@"name"]] : nil;
+  NSString *email = personInfo[@"email"] && ![personInfo[@"email"] isEqual:[NSNull null]]
+    ? [RCTConvert NSString:personInfo[@"email"]] : nil;
   [[Rollbar currentConfiguration] setPersonId:identifier username:name email:email];
 }
 


### PR DESCRIPTION
## Description of the change

Update export method to expect `NSNull` or `NSString`. This wasn't a problem in the 0.x builds, but it is definitely failing now when setting any of these keys to null.

Tested manually.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

Fixes https://app.shortcut.com/rollbar/story/121821/


### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Issue from task tracker has a link to this pull request
- [x] Changes have been reviewed by at least one other engineer
