### PR TITLE
Fix for mutable config

### DIFF
--- a/ios/RollbarReactNative.m
+++ b/ios/RollbarReactNative.m
@@ -22,6 +22,7 @@ static NSString *const REACT_NATIVE = @"react-native";
   RollbarMutableConfig *config = [[Rollbar configuration] mutableCopy];
   if (config) {
     updateConfiguration(config, options);
+    [Rollbar updateWithConfiguration:config];
     return;
   }
   config = [RollbarConfig mutableConfigWithAccessToken:[RCTConvert NSString:options[@"accessToken"]]];
@@ -376,6 +377,7 @@ RCT_EXPORT_METHOD(init:(NSDictionary *)options) {
   RollbarMutableConfig *config = [[Rollbar configuration] mutableCopy];
   if (config) {
     updateConfiguration(config, options);
+      [Rollbar updateWithConfiguration:config];
     return;
   }
   config = [RollbarConfig mutableConfigWithAccessToken:[RCTConvert NSString:options[@"accessToken"]]];
@@ -391,11 +393,15 @@ RCT_EXPORT_METHOD(setPerson:(NSDictionary *)personInfo) {
     ? [RCTConvert NSString:personInfo[@"name"]] : nil;
   NSString *email = personInfo[@"email"] && ![personInfo[@"email"] isEqual:[NSNull null]]
     ? [RCTConvert NSString:personInfo[@"email"]] : nil;
-  [[[Rollbar configuration] mutableCopy] setPersonId:identifier username:name email:email];
+  RollbarMutableConfig *config = [[Rollbar configuration] mutableCopy];
+  [config setPersonId:identifier username:name email:email];
+  [Rollbar updateWithConfiguration:config];
 }
 
 RCT_EXPORT_METHOD(clearPerson) {
-  [[[Rollbar configuration] mutableCopy] setPersonId:@"" username:nil email:nil];
+  RollbarMutableConfig *config = [[Rollbar configuration] mutableCopy];
+  [config setPersonId:@"" username:nil email:nil];
+  [Rollbar updateWithConfiguration:config];
 }
 
 // Defined as synchronous because the data must be returned in the

--- a/ios/RollbarReactNative.m
+++ b/ios/RollbarReactNative.m
@@ -19,7 +19,7 @@ static NSString *const NOTIFIER_VERSION = @"1.0.0-beta.0";
 static NSString *const REACT_NATIVE = @"react-native";
 
 + (void)initWithConfiguration:(NSDictionary*)options {
-  RollbarMutableConfig *config = ((RollbarMutableConfig *)[Rollbar configuration]);
+  RollbarMutableConfig *config = [[Rollbar configuration] mutableCopy];
   if (config) {
     updateConfiguration(config, options);
     return;
@@ -373,7 +373,7 @@ void updateConfiguration(RollbarMutableConfig *config, NSDictionary *options) {
 RCT_EXPORT_MODULE()
 
 RCT_EXPORT_METHOD(init:(NSDictionary *)options) {
-  RollbarMutableConfig *config = (RollbarMutableConfig *)[Rollbar configuration];
+  RollbarMutableConfig *config = [[Rollbar configuration] mutableCopy];
   if (config) {
     updateConfiguration(config, options);
     return;
@@ -391,11 +391,11 @@ RCT_EXPORT_METHOD(setPerson:(NSDictionary *)personInfo) {
     ? [RCTConvert NSString:personInfo[@"name"]] : nil;
   NSString *email = personInfo[@"email"] && ![personInfo[@"email"] isEqual:[NSNull null]]
     ? [RCTConvert NSString:personInfo[@"email"]] : nil;
-  [((RollbarMutableConfig *)[Rollbar configuration]) setPersonId:identifier username:name email:email];
+  [[[Rollbar configuration] mutableCopy] setPersonId:identifier username:name email:email];
 }
 
 RCT_EXPORT_METHOD(clearPerson) {
-  [((RollbarMutableConfig *)[Rollbar configuration]) setPersonId:@"" username:nil email:nil];
+  [[[Rollbar configuration] mutableCopy] setPersonId:@"" username:nil email:nil];
 }
 
 // Defined as synchronous because the data must be returned in the


### PR DESCRIPTION
When making changes to the configuration (setting access token, changing user etc), a non-mutable config is used.

This change calls `mutableCopy` on the RollbarConfig instead of just casting it to a RollbarMutableConfig.

## Type of change

- Bug fix (non-breaking change that fixes an issue)

## Related issues

- #178

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
