### PR TITLE
Add namespace in build.gradle for RN 73 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+        namespace "com.rollbar"
+    }
+
     compileSdkVersion project.hasProperty('compileSdkVersion') ? project.compileSdkVersion : 27
     buildToolsVersion project.hasProperty('buildToolsVersion') ? project.buildToolsVersion : "27.0.3"
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,2 @@
-
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.rollbar">
-
-</manifest>
+<manifest package="com.rollbar" />
   


### PR DESCRIPTION
## Description of the change

For Android, will Add namespace in build.gradle for RN 73 compatibility 
React Native main topic:
https://github.com/react-native-community/discussions-and-proposals/issues/671

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

- Fix android-fix-namespace-for-rn-73

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
