### PR TITLE
Use latest Rollbar Apple SDK 3.3.1

### DIFF
--- a/RollbarReactNative.podspec
+++ b/RollbarReactNative.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency 'React-Core'
-  s.dependency 'RollbarNotifier', '3.2.0'
+  s.dependency 'RollbarNotifier', '3.3.1'
   s.source_files  = 'ios/RollbarReactNative.{h,m}'
   s.public_header_files = 'ios/RollbarReactNative.h'
 


### PR DESCRIPTION
## Description of the change

This PR updates the SDK to use the latest Rollbar Apple SDK 3.3.1 which fixes a compilation issue with Xcode 16 beta.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

- Fix [SDK-365](https://linear.app/rollbar-inc/issue/SDK-365/rollbar-wont-compile-for-a-swift-mac-os-app)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
