### PR TITLE
Bumped minimum deployment to 13 tracking React-Core dep minimum

### DIFF
--- a/RollbarReactNative.podspec
+++ b/RollbarReactNative.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'https://rollbar.com'
   s.license      = 'MIT'
   s.author       = { 'Rollbar' => 'support@rollbar.com' }
-  s.platform     = :ios, '7.0'
+  s.platform     = :ios, '13.0'
   s.source       = { :git => 'https://github.com/rollbar/rollbar-react-native.git', :tag => '1.0.0-beta.2' }
   s.requires_arc = true
 


### PR DESCRIPTION
## Description of the change

The latest React-Core dependency used by the SDK has upped its ios minimum deployment version to 13.0. This is probably due to Apple dropping older versions of the os.

Without this, the podspec will fail to lint.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release
