### PR TITLE
Use latest Rollbar Apple SDK 3.3.2

### DIFF
--- a/RollbarReactNative.podspec
+++ b/RollbarReactNative.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency 'React-Core'
-  s.dependency 'RollbarNotifier', '3.3.1'
+  s.dependency 'RollbarNotifier', '3.3.2'
   s.source_files  = 'ios/RollbarReactNative.{h,m}'
   s.public_header_files = 'ios/RollbarReactNative.h'
 


### PR DESCRIPTION
## Description of the change

This PR updates the SDK to use the latest Rollbar Apple SDK 3.3.2 which fixes more compilation issues with Xcode 16 beta.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

- Fix https://github.com/rollbar/rollbar-react-native/issues/195
