### PR TITLE
FIX: adjust podspec file to refer to proper branch name

### DIFF
--- a/RollbarReactNative.podspec
+++ b/RollbarReactNative.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license      = 'MIT'
   s.author       = { 'Rollbar' => 'support@rollbar.com' }
   s.platform     = :ios, '13.0'
-  s.source       = { :git => 'https://github.com/rollbar/rollbar-react-native.git', :tag => 'v1.0.0-beta.4a' }
+  s.source       = { :git => 'https://github.com/rollbar/rollbar-react-native.git', :tag => 'v1.0.0-beta.4' }
   s.requires_arc = true
 
   s.dependency 'React-Core'

--- a/RollbarReactNative.podspec
+++ b/RollbarReactNative.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license      = 'MIT'
   s.author       = { 'Rollbar' => 'support@rollbar.com' }
   s.platform     = :ios, '13.0'
-  s.source       = { :git => 'https://github.com/rollbar/rollbar-react-native.git', :tag => '1.0.0-beta.4' }
+  s.source       = { :git => 'https://github.com/rollbar/rollbar-react-native.git', :tag => 'v1.0.0-beta.4a' }
   s.requires_arc = true
 
   s.dependency 'React-Core'


### PR DESCRIPTION
## Description of the change

Adjust podspec to refer to proper branch name, [works on Cocoa Pod install now:](https://github.com/rollbar/rollbar-react-native/issues/198)
![image](https://github.com/user-attachments/assets/5b371c37-251d-44f8-928c-e2b34d808816)


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

- Fix #198

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [x] Changes have been reviewed by at least one other engineer
