### PR TITLE
Use latest Rollbar Apple SDK 3.3.3

### DIFF
--- a/RollbarReactNative.podspec
+++ b/RollbarReactNative.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency 'React-Core'
-  s.dependency 'RollbarNotifier', '3.3.2'
+  s.dependency 'RollbarNotifier', '3.3.3'
   s.source_files  = 'ios/RollbarReactNative.{h,m}'
   s.public_header_files = 'ios/RollbarReactNative.h'
 


### PR DESCRIPTION
## Description of the change

This upgrades the Rollbar Apple SDK used by the Rollbar React Native SDK to the latest version which fixes a few compilation issues when using barebones react-native projects.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release
