### PR TITLE
[Fix][SDK-436] Expo crash on init

### DIFF
--- a/android/src/main/java/com/rollbar/RollbarReactNative.java
+++ b/android/src/main/java/com/rollbar/RollbarReactNative.java
@@ -41,6 +41,7 @@ public class RollbarReactNative extends ReactContextBaseJavaModule {
 
   public RollbarReactNative(ReactApplicationContext reactContext) {
     super(reactContext);
+    Rollbar.init(reactContext);
     this.reactContext = reactContext;
   }
 

--- a/android/src/main/java/com/rollbar/RollbarReactNative.java
+++ b/android/src/main/java/com/rollbar/RollbarReactNative.java
@@ -526,12 +526,16 @@ public class RollbarReactNative extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void init(ReadableMap options) {
+    Rollbar rollbar = Rollbar.instance();
+    if (rollbar == null) {
+      return;
+    }
     final String environment = options.hasKey("environment") ? options.getString("environment") : "production";
     final String platform = options.hasKey("platform") ? options.getString("platform") : "android";
     final String notifier_version = options.hasKey("notifier") ? options.getMap("notifier").getString("version") : NOTIFIER_VERSION;
     final String notifier_name = options.hasKey("notifier") ? options.getMap("notifier").getString("name") : NOTIFIER_NAME;
     final boolean enabled = options.hasKey("enabled") ? options.getBoolean("enabled") : true;
-    Rollbar.instance().configure(new ConfigProvider() {
+    rollbar.configure(new ConfigProvider() {
       @Override
       public Config provide(ConfigBuilder builder) {
         return builder


### PR DESCRIPTION
## Description of the change

Init Android notifier on RollbarReactNative constructor

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

- Fix [SC-]
- Fix #1

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
